### PR TITLE
Fixed 'cudnn` path for `tf_nopip` version and added `keras-tuner` to `tf_pip` version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ Third, the `XLA_FLAGS` environment variable needs to be set to include the path 
 4. Start a batch job on a gpu node. You can start a 30 minute testing job with `execcasper -l select=1:ncpus=1:mem=20GB:ngpus=1 --gpu_type=v100 -q gpudev -A $PROJECT_ID` 
 5. Activate the environment with `module load conda` and `conda activate tfXXXgpu`. 
 6. Run `python test_simple_nn.py` to test that the GPU is detected correctly and that a simple neural net will train on the GPU. 
+
+## `pip` vs `nopip`
+
+The `pip` installation method provided in this repository is that recommended by Google which provides TensorFlow. The `nopip` version is community supported and ditributed primarily through `conda-forge`.
+
+In general, pure installations using `conda` are easier to maintain compared to `pip` based installations. It is relatively easy to break dependency requirements when mixing `pip` and `conda` installs. Nonetheless, the `pip` version of TensorFlow does include utility of the `tensorrt` framework since the Python Package Index distributes the `pip` version with this functionality. Additionally, the `pip` version includes instruction sets for CPU operations up to AVX while the `conda` version provides only up to SSE3. 
+
+Please consider these differences when choosing to install a version of TensorFlow.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Setup TensorFlow on Casper
 
 This package provides scripts to setup [Tensorflow using `pip`](tf_pip) or [Tensorflow without using `pip`](tf_nopip) with GPU support on casper without using any outside CUDA modules.
-The key steps for setting up TensorFlow are to first install the correct versions of `cudatoolkit` and `cudnn` packages using the Casper `conda` module. 
-Second, environment variables need to be set correctly to point TensorFlow to the conda-based CUDA installation.
-Third, the `XLA_FLAGS` environment variable needs to be set to include the path to the conda environment. 
+The key steps for setting up TensorFlow are to first install the correct versions of `cudatoolkit` and `cudnn` packages using the Casper `conda` module. 'tensorrt' is also installed for the `pip` version. 
+Second, environment variables need to be set correctly to point TensorFlow to the conda-based CUDA installation and associated libraries. These are set during the activation of each conda environment.
+Third, the `XLA_FLAGS` environment variable needs to be set to include the path to the conda environment.
 
 ## Setup
 
 1. (Optional) Install [MiniConda](https://docs.conda.io/en/latest/miniconda.html) or [MambaForge](https://github.com/conda-forge/miniforge) to your local machine if not running on Casper. 
 2. `cd` to `tf_pip` or `tf_nopip` depending on desire to use TensorFlow installed with pip or installed from `conda-forge` channel.
 3. Run `sh setup_conda_tfXXX.sh` where XXX is the version number in [tf_pip](tf_pip) or [tf_nopip](tf_nopip). This creates a conda environment with TensorFlow and the appropriate libraries and environment variables.
-4. Start a batch job on a gpu node. You can start a 30 minute testing job with `execcasper -A $PROJECT_ID -l select=1:ncpus=1:mem=20GB:ngpus=1 --gpu_type=v100 -q gpudev` 
+4. Start a batch job on a gpu node. You can start a 30 minute testing job with `execcasper -l select=1:ncpus=1:mem=20GB:ngpus=1 --gpu_type=v100 -q gpudev -A $PROJECT_ID` 
 5. Activate the environment with `module load conda` and `conda activate tfXXXgpu`. 
 6. Run `python test_simple_nn.py` to test that the GPU is detected correctly and that a simple neural net will train on the GPU. 

--- a/tf_nopip/activate_env_vars.sh
+++ b/tf_nopip/activate_env_vars.sh
@@ -1,6 +1,12 @@
 export OLD_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CONDA_PREFIX}/lib/
+
+export CUDNN_PATH=${CONDA_PREFIX}
+export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib/:${LD_LIBRARY_PATH}
+
 export XLA_FLAGS=--xla_gpu_cuda_data_dir=${CONDA_PREFIX}
+
+# For CUDA Aware MPI support
+export OMPI_MCA_opal_cuda_support=true
 
 # For TF optimizations, see https://github.com/NVIDIA/DeepLearningExamples/issues/57
 export TF_GPU_THREAD_MODE=gpu_private

--- a/tf_nopip/deactivate_env_vars.sh
+++ b/tf_nopip/deactivate_env_vars.sh
@@ -1,6 +1,10 @@
+unset CUDNN_PATH
 unset XLA_FLAGS
+
 export LD_LIBRARY_PATH=${OLD_LD_LIBRARY_PATH}
 unset OLD_LD_LIBRARY_PATH
+
+unset OMPI_MCA_opal_cuda_support
 
 unset TF_GPU_THREAD_MODE
 unset TF_GPU_THREAD_COUNT

--- a/tf_nopip/tf211_nopip_env.yml
+++ b/tf_nopip/tf211_nopip_env.yml
@@ -11,7 +11,7 @@ dependencies:
   - hdf5=*=*openmpi*
   - h5py=*=*openmpi*
   - cudatoolkit=11.2.*
-  - cuda-nvcc=11.2.*
+  - cuda-nvcc=11.8.*
   - tensorflow=2.11.*=cuda*
-  - cudnn=8.1.*
+  - cudnn
   - keras-tuner

--- a/tf_nopip/tf211_nopip_env.yml
+++ b/tf_nopip/tf211_nopip_env.yml
@@ -8,6 +8,8 @@ dependencies:
   - numpy
   - scipy
   - pandas
+  - hdf5=*=*openmpi*
+  - h5py=*=*openmpi*
   - cudatoolkit=11.8.*
   - cuda-nvcc=11.8.*
   - tensorflow=2.11.*=cuda*

--- a/tf_nopip/tf211_nopip_env.yml
+++ b/tf_nopip/tf211_nopip_env.yml
@@ -10,9 +10,8 @@ dependencies:
   - pandas
   - hdf5=*=*openmpi*
   - h5py=*=*openmpi*
-  - cudatoolkit=11.8.*
-  - cuda-nvcc=11.8.*
+  - cudatoolkit=11.2.*
+  - cuda-nvcc=11.2.*
   - tensorflow=2.11.*=cuda*
-  - cudnn
-  - keras
+  - cudnn=8.1.*
   - keras-tuner

--- a/tf_nopip/tf212_nopip_env.yml
+++ b/tf_nopip/tf212_nopip_env.yml
@@ -13,5 +13,5 @@ dependencies:
   - cudatoolkit=11.8.*
   - cuda-nvcc=11.8.*
   - tensorflow=2.12.*=cuda*
-  - cudnn=8.6.*
+  - cudnn
   - keras-tuner

--- a/tf_nopip/tf212_nopip_env.yml
+++ b/tf_nopip/tf212_nopip_env.yml
@@ -13,6 +13,5 @@ dependencies:
   - cudatoolkit=11.8.*
   - cuda-nvcc=11.8.*
   - tensorflow=2.12.*=cuda*
-  - cudnn
-  - keras
+  - cudnn=8.6.*
   - keras-tuner

--- a/tf_nopip/tf212_nopip_env.yml
+++ b/tf_nopip/tf212_nopip_env.yml
@@ -8,6 +8,8 @@ dependencies:
   - numpy
   - scipy
   - pandas
+  - hdf5=*=*openmpi*
+  - h5py=*=*openmpi*
   - cudatoolkit=11.8.*
   - cuda-nvcc=11.8.*
   - tensorflow=2.12.*=cuda*

--- a/tf_pip/activate_env_vars.sh
+++ b/tf_pip/activate_env_vars.sh
@@ -1,7 +1,13 @@
 export OLD_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+
 export CUDNN_PATH=${CONDA_PREFIX}/lib/python3.10/site-packages/nvidia/cudnn
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CONDA_PREFIX}/lib/:${CUDNN_PATH}/lib
+export TENSORRT_PATH=${CONDA_PREFIX}/lib/python3.10/site-packages/tensorrt_libs
+export LD_LIBRARY_PATH=${CUDNN_PATH}/lib:${TENSORRT_PATH}:${CONDA_PREFIX}/lib/:${LD_LIBRARY_PATH}
+
 export XLA_FLAGS=--xla_gpu_cuda_data_dir=${CONDA_PREFIX}
+
+# For CUDA Aware MPI support
+export OMPI_MCA_opal_cuda_support=true
 
 # For TF optimizations, see https://github.com/NVIDIA/DeepLearningExamples/issues/57
 export TF_GPU_THREAD_MODE=gpu_private

--- a/tf_pip/deactivate_env_vars.sh
+++ b/tf_pip/deactivate_env_vars.sh
@@ -1,7 +1,11 @@
 unset CUDNN_PATH
+unset TENSORRT_PATH
 unset XLA_FLAGS
+
 export LD_LIBRARY_PATH=${OLD_LD_LIBRARY_PATH}
 unset OLD_LD_LIBRARY_PATH
+
+unset OMPI_MCA_opal_cuda_support
 
 unset TF_GPU_THREAD_MODE
 unset TF_GPU_THREAD_COUNT

--- a/tf_pip/setup_conda_tf212.sh
+++ b/tf_pip/setup_conda_tf212.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 module load conda
 
-CONDA_OVERRIDE_CUDA="11.8" mamba env create -f tf212_env.yml
+CONDA_OVERRIDE_CUDA="11.8" mamba env create -f tf212_pip_env.yml
 
 conda activate tf212gpu
 

--- a/tf_pip/setup_conda_tf213.sh
+++ b/tf_pip/setup_conda_tf213.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 module load conda
 
-CONDA_OVERRIDE_CUDA="11.8" mamba env create -f tf213_env.yml
+CONDA_OVERRIDE_CUDA="11.8" mamba env create -f tf213_pip_env.yml
 
 conda activate tf213gpu
 

--- a/tf_pip/tf212_pip_env.yml
+++ b/tf_pip/tf212_pip_env.yml
@@ -16,7 +16,7 @@ dependencies:
   - cuda-nvcc=11.8.*
   - pip
   - pip:
-    - nvidia-cudnn-cu11==8.6.0.163
+    - nvidia-cudnn-cu11==8.6.*
     - tensorrt
     - tensorflow==2.12.*
     - keras-tuner

--- a/tf_pip/tf212_pip_env.yml
+++ b/tf_pip/tf212_pip_env.yml
@@ -8,6 +8,8 @@ dependencies:
   - numpy=1.24.3
   - scipy
   - pandas
+  - hdf5=*=*openmpi*
+  - h5py=*=*openmpi*
   - typing-extensions=4.5.0
   - urllib3=1.26.15
   - cudatoolkit=11.8.*

--- a/tf_pip/tf212_pip_env.yml
+++ b/tf_pip/tf212_pip_env.yml
@@ -19,3 +19,4 @@ dependencies:
     - nvidia-cudnn-cu11==8.6.0.163
     - tensorrt
     - tensorflow==2.12.*
+    - keras-tuner

--- a/tf_pip/tf212_pip_env.yml
+++ b/tf_pip/tf212_pip_env.yml
@@ -15,4 +15,5 @@ dependencies:
   - pip
   - pip:
     - nvidia-cudnn-cu11==8.6.0.163
+    - tensorrt
     - tensorflow==2.12.*

--- a/tf_pip/tf213_pip_env.yml
+++ b/tf_pip/tf213_pip_env.yml
@@ -19,3 +19,4 @@ dependencies:
     - nvidia-cudnn-cu11==8.6.0.163
     - tensorrt
     - tensorflow==2.13.*
+    - keras-tuner

--- a/tf_pip/tf213_pip_env.yml
+++ b/tf_pip/tf213_pip_env.yml
@@ -8,6 +8,8 @@ dependencies:
   - numpy=1.24.3
   - scipy
   - pandas
+  - hdf5=*=*openmpi*
+  - h5py=*=*openmpi*
   - typing-extensions=4.5.0
   - urllib3=1.26.15
   - cudatoolkit=11.8.*
@@ -15,4 +17,5 @@ dependencies:
   - pip
   - pip:
     - nvidia-cudnn-cu11==8.6.0.163
+    - tensorrt
     - tensorflow==2.13.*

--- a/tf_pip/tf213_pip_env.yml
+++ b/tf_pip/tf213_pip_env.yml
@@ -16,7 +16,7 @@ dependencies:
   - cuda-nvcc=11.8.*
   - pip
   - pip:
-    - nvidia-cudnn-cu11==8.6.0.163
+    - nvidia-cudnn-cu11==8.6.*
     - tensorrt
     - tensorflow==2.13.*
     - keras-tuner


### PR DESCRIPTION
The installation using only `conda-forge` had an issue now resolved. The path to `cudnn` libraries installed via conda sets the path differently than when installed via `pip`, which is corrected the `$CONDA_PREFIX`.

Also added `keras-tuner` to `tf_pip` version to match what is installed in `tf_nopip` version.

Lastly, `tensorrt` is part of the TensorFlow compilation when distributed via PyPI. Thus, installed `tensorrt` for the `tf_pip` version only and added environment variables to reference this library correctly. This removes the TensorRT warning message.

Other general formatting and naming updates were made, including the `README.md`.